### PR TITLE
Include apple touch icons in the icons result

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -678,7 +678,11 @@ export class Handler {
               type: typeAttr || "application/rdf+xml",
               href: resolveUrl(this.options.url, hrefAttr)
             });
-          } else if (rel === "icon") {
+          } else if (
+            rel === "icon" ||
+            rel === "apple-touch-icon" ||
+            rel === "apple-touch-icon-precomposed"
+          ) {
             appendAndDedupe(this.result.icons, ["href"], {
               type: typeAttr,
               sizes: normalize(attributes["sizes"]),


### PR DESCRIPTION
Thanks for a great library!
So much faster and uses less resources than those libraries that use Cheerio.

I saw that Apple touch icons are missing from the result though, and they are usually of better resolution than the standard favicon.ico.

This adds support for those icons and returns them in the `icons: Array<Icon>` result property.