### PR TITLE
missing field language in ResultHtml type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -372,6 +372,7 @@ export class Handler {
     if (langAttr) {
       this.langs.push(langAttr);
       context.flags = context.flags | HandlerFlags.hasLang;
+      set(this.result, ["html", "language"], langAttr);
     }
 
     // Store `id` references for later (microdata itemrefs).


### PR DESCRIPTION
Hello 👋,

The language attribute from HtlmTag wasn't set in Html result but was defined in ResultHtml interface,
This mr should resolve it,
